### PR TITLE
Fix video to show clearly

### DIFF
--- a/app/src/main/java/com/qsp/player/util/HtmlUtil.java
+++ b/app/src/main/java/com/qsp/player/util/HtmlUtil.java
@@ -30,6 +30,10 @@ public final class HtmlUtil {
         Element body = document.body();
         body.select("img").attr("style", "max-width: 100%;");
 
+        // video setting
+        body.select("video").attr("style", "max-width: 100%;");
+        body.select("video").attr("muted", "true");
+
         return document.toString();
     }
 


### PR DESCRIPTION
After update of seedhartha. Thankfully, many bugs have been fixed,
but some bugs have been created. One of them is that video dosen't
play automatically and width of video is set beyond the screen.

Add mute, style attributes for video from HtmlUtil.java